### PR TITLE
Fix indentation of the parse tree output

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ fn parse_input() {
         match vm.parse(&rule, &input.value()) {
             Ok(pairs) => {
                 let lines: Vec<_> = pairs.map(|pair| {
-                    format_pair(pair, 0)
+                    format_pair(pair, 0, true)
                 }).collect();
                 let lines = lines.join("\n");
 
@@ -67,23 +67,23 @@ fn parse_input() {
     }
 }
 
-fn format_pair(pair: Pair<&str>, indent_level: u32) -> String {
-    let mut indent = String::new();
-
-    for _ in 0..indent_level {
-        indent.push_str("  ");
-    }
+fn format_pair(pair: Pair<&str>, indent_level: usize, is_newline: bool) -> String {
+    let indent = if is_newline {
+        "  ".repeat(indent_level)
+    } else {
+        "".to_string()
+    };
 
     let children: Vec<_> = pair.clone().into_inner().collect();
     let len = children.len();
     let children: Vec<_> = children.into_iter().map(|pair| {
-        format_pair(pair, if len > 1 { indent_level + 1 } else { 0 })
+        format_pair(pair, if len > 1 { indent_level + 1 } else { indent_level }, len > 1)
     }).collect();
 
-    let dash = if indent_level == 0 {
-        ""
-    } else {
+    let dash = if is_newline {
         "- "
+    } else {
+        ""
     };
 
     match len {


### PR DESCRIPTION
The editor on the website gives poorly indented output. Here's an example grammar:
```
full = { expr ~ EOI }
expr = { term ~ op ~ term }
term = { number }

digit = { '0'..'9' }
number = { ("+"|"-")? ~ digit+ }
op = { "*" | "/" | "+" | "-" }
```
Feeding it the input `10+10` gives the following output:
```
full
  - expr
    - term > number
  - digit: "1"
  - digit: "0"
    - op: "+"
    - term > number
  - digit: "1"
  - digit: "0"
  - EOI: ""
```
This is because when `format_pair` prints `- term > number` it throws away the indentation information. This patch should give the following output:
```
full
  - expr
    - term > number
      - digit: "1"
      - digit: "0"
    - op: "+"
    - term > number
      - digit: "1"
      - digit: "0"
  - EOI: ""
```
I haven't tested this directly because builds with wasm don't work yet on my system. But the logic worked when I used it in another project.