### PR TITLE
Remove ligatures

### DIFF
--- a/static/codemirror/lib/codemirror.css
+++ b/static/codemirror/lib/codemirror.css
@@ -252,8 +252,8 @@ div.CodeMirror span.CodeMirror-nonmatchingbracket {color: #a22;}
   position: relative;
   overflow: visible;
   -webkit-tap-highlight-color: transparent;
-  -webkit-font-variant-ligatures: contextual;
-  font-variant-ligatures: contextual;
+  -webkit-font-variant-ligatures: none;
+  font-variant-ligatures: none;
 }
 .CodeMirror-wrap pre {
   word-wrap: break-word;


### PR DESCRIPTION
Closes pest-parser/pest#419

I will readily admit that I do not know whether changing `webkit-font-variant-ligatures` is actually needed, but might as well get them all.