### PR TITLE
ci: github actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,3 @@
-
 name: publish
 
 on:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,9 @@ name: publish
 
 on:
   pull_request:
-    branches: [main]
+    branches: [master]
   push:
-    branches: [main]
+    branches: [master]
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,51 @@
+
+name: publish
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    if: github.event_name != 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Task
+        uses: arduino/setup-task@v1
+      - name: Run Build
+        run: go-task
+  gh-release:
+    if: github.event_name != 'pull_request'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install Task
+        uses: arduino/setup-task@v1
+      - name: Run Build
+        run: go-task
+      - name: Setup Pages
+        uses: actions/configure-pages@v2
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: 'www'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "book"]
+	path = book
+	url = https://github.com/pest-parser/book

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -8,8 +8,12 @@ vars:
 tasks:
   default:
     cmds:
-      - mkdir -p www
+      - mkdir -p {{.WEBROOT}}
       - rm -rf {{.WEBROOT}}/*
+      - rm -rf book/book/*
+      - mdbook build book -d book/book
+      - mkdir -p {{.WEBROOT}}/book
+      - cp -R book/book/book/* {{.WEBROOT}}/book
       - wasm-pack build --target web
       - cp -R static/* {{.WEBROOT}}/
       - cp pkg/*.js {{.WEBROOT}}

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -8,8 +8,9 @@ vars:
 tasks:
   default:
     cmds:
-      - mkdir -p {{.WEBROOT}}/book
+      - mkdir -p {{.WEBROOT}}
       - rm -rf {{.WEBROOT}}/*
+      - mkdir -p {{.WEBROOT}}/book
       - rm -rf book/book/*
 
       - mdbook build book -d book/book

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -8,13 +8,14 @@ vars:
 tasks:
   default:
     cmds:
-      - mkdir -p {{.WEBROOT}}
+      - mkdir -p {{.WEBROOT}}/book
       - rm -rf {{.WEBROOT}}/*
       - rm -rf book/book/*
+
       - mdbook build book -d book/book
-      - mkdir -p {{.WEBROOT}}/book
-      - cp -R book/book/book/* {{.WEBROOT}}/book
       - wasm-pack build --target web
+
+      - cp -R book/book/book/* {{.WEBROOT}}/book
       - cp -R static/* {{.WEBROOT}}/
       - cp pkg/*.js {{.WEBROOT}}
       - cp pkg/*.wasm {{.WEBROOT}}


### PR DESCRIPTION
This adds GitHub actions support and deployment, with the following:

- pest-parser/book submodule
- GitHub deployment action
- Integrates mdbook into taskfile

Currently testing out actions on my own branch before I undraft this PR.
(In the process, had some branch mixups as I'm trying to be on the master branch to test out CI.)