### PR TITLE
ci: add repo token to setup-task

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,6 +35,8 @@ jobs:
           version: 'latest'
       - name: Install Task
         uses: arduino/setup-task@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run Build
         run: task
   gh-release:


### PR DESCRIPTION
rate-limiting is causing issues (e.g. #25) so the [repo-token](https://github.com/arduino/setup-task#repo-token) property should be set.

This should have been the default (https://github.com/arduino/setup-task/pull/642) but is currently not the case.