### PR TITLE
fix: use an absolute path for og:image

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -34,7 +34,7 @@
     <meta name="og:title" content="pest">
     <meta name="og:description" content="The Elegant Parser">
     <meta name="og:url" content="https://pest.rs">
-    <meta name="og:image" content="assets/pest-logo.png">
+    <meta name="og:image" content="https://pest.rs/assets/pest-logo.png">
     <meta name="og:image:alt" content="The pest Logo.">
     <meta name="og:site_name" content="pest.rs">
     <meta name="og:locale" content="en_US">


### PR DESCRIPTION
The trilogy comes to an end...

I apologize for the shitshow this `og:image` has come to :laughing:. I ended up just serving the site locally and using ngrok to test it out this time - seems opengraph does not support relative URLs :/

![FINALLY!](https://user-images.githubusercontent.com/56727311/219938807-289c8282-bbaf-4e7f-8297-c7c0d5883a14.png)
