### PR TITLE
fix: make wideMode global

### DIFF
--- a/static/index.html
+++ b/static/index.html
@@ -548,7 +548,7 @@
           }
         }
       }
-      function wideMode() {
+      window.wideMode = function() {
         modeBtn.onclick = restore;
         modeBtn.innerText = "Normal Mode";
         inputDom.classList.add("wide-input");


### PR DESCRIPTION
this fixes [an issue](https://github.com/pest-parser/site/pull/30#issuecomment-1454314603) mentioned in #30 by making wideMode global. This may be superseded by the transfer to typescript in the future (which _should_ reduce the reliance on global functions).