### PR TITLE
Added support for tags labels and localstorage save

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,20 +131,32 @@ fn format_pair(pair: Pair<&str>, indent_level: usize, is_newline: bool) -> Strin
         .collect();
 
     let dash = if is_newline { "- " } else { "" };
-
+    let pair_tag = match pair.as_node_tag() {
+        Some(tag) => format!("(#{}) ", tag),
+        None => String::new(),
+    };
     match len {
         0 => format!(
-            "{}{}{}: {:?}",
+            "{}{}{}{}: {:?}",
             indent,
             dash,
+            pair_tag,
             pair.as_rule(),
             pair.as_span().as_str()
         ),
-        1 => format!("{}{}{} > {}", indent, dash, pair.as_rule(), children[0]),
-        _ => format!(
-            "{}{}{}\n{}",
+        1 => format!(
+            "{}{}{}{} > {}",
             indent,
             dash,
+            pair_tag,
+            pair.as_rule(),
+            children[0]
+        ),
+        _ => format!(
+            "{}{}{}{}\n{}",
+            indent,
+            dash,
+            pair_tag,
             pair.as_rule(),
             children.join("\n")
         ),

--- a/static/scripts/editor.ts
+++ b/static/scripts/editor.ts
@@ -180,9 +180,13 @@ formatBtn.onclick = doFormat;
 
 init().then(() => {
   loaded = true
-  const { grammar, input } = getSavedCode();
-  myCodeMirror.setValue(grammar);
-  inputTextDom.value = input;
+  const url = new URL(window.location.href);
+  const hasUrlGrammar = url.searchParams.get("g");
+  if(!hasUrlGrammar){
+    const { grammar, input } = getSavedCode();
+    myCodeMirror.setValue(grammar);
+    inputTextDom.value = input;
+  }
 });
 
 inputTextDom.addEventListener("input", saveCode);

--- a/static/scripts/editor.ts
+++ b/static/scripts/editor.ts
@@ -11,6 +11,7 @@ let loaded = false;
 const editorDom = document.querySelector<HTMLLinkElement>(".editor")!;
 const gridDom = document.querySelector<HTMLDivElement>(".editor-grid")!;
 const inputDom = document.querySelector<HTMLDivElement>(".editor-input")!;
+const inputTextDom = document.querySelector<HTMLTextAreaElement>('.editor-input-text')!;
 const outputDom =
   document.querySelector<HTMLTextAreaElement>(".editor-output")!;
 const modeBtn = document.querySelector<HTMLButtonElement>("#modeBtn")!;
@@ -20,23 +21,29 @@ const windowHeight = window.innerHeight;
 
 CodeMirror.defineSimpleMode("pest", {
   start: [
+    { regex: /\/\/.*/, token: "comment" },
+    { regex: /[a-zA-Z_]\w*/, token: "constiable" },
+    { regex: /=/, token: "operator", next: "mod" },
+  ],
+  mod: [
+    { regex: /\{/, token: "bracket", next: "inside_rule" },
+    { regex: /[_@!$]/, token: "operator-2" },
+  ],
+  inside_rule: [
     { regex: /"/, token: "string", next: "string" },
     {
       regex: /'(?:[^'\\]|\\(?:[nrt0'"]|x[\da-fA-F]{2}|u\{[\da-fA-F]{6}\}))'/,
       token: "string",
     },
-    { regex: /\/\/.*/, token: "comment" },
+    { regex: /\}/, token: "bracket", next: "start" },
+    { regex: /#\w+/, token: "tag" },
+    { regex: /[a-zA-Z_]\w*/, token: "constiable-2" },
+    { regex: /=/, token: "operator-2" },
     { regex: /\d+/, token: "number" },
     { regex: /[~|*+?&!]|(\.\.)/, token: "operator" },
-    { regex: /[a-zA-Z_]\w*/, token: "constiable" },
-    { regex: /=/, next: "mod" },
-  ],
-  mod: [
-    { regex: /\{/, next: "start" },
-    { regex: /[_@!$]/, token: "operator-2" },
   ],
   string: [
-    { regex: /"/, token: "string", next: "start" },
+    { regex: /"/, token: "string", next: "inside_rule" },
     { regex: /(?:[^\\"]|\\(?:.|$))*/, token: "string" },
   ],
   meta: {
@@ -44,6 +51,12 @@ CodeMirror.defineSimpleMode("pest", {
     lineComment: "//",
   },
 });
+
+
+
+
+
+
 
 CodeMirror.registerHelper("lint", "pest", function (text) {
   if (loaded) {
@@ -121,6 +134,23 @@ function makeResizable(wideMode: boolean) {
   }
 }
 
+type SavedGrammar = {
+  grammar: string;
+  input: string;
+};
+function saveCode() {
+  const grammar = myCodeMirror.getValue();
+  const input = inputTextDom.value;
+  const json = JSON.stringify({ grammar, input } satisfies SavedGrammar);
+  localStorage.setItem("last-editor-state", json);
+}
+function getSavedCode() {
+  const json = localStorage.getItem("last-editor-state")
+  const parsed = JSON.parse(json || "null")
+  return parsed || { grammar: "", input: "" }
+}
+
+
 function wideMode() {
   modeBtn.onclick = restore;
   modeBtn.innerText = "Normal Mode";
@@ -148,4 +178,12 @@ function restore() {
 modeBtn.onclick = wideMode;
 formatBtn.onclick = doFormat;
 
-init().then(() => (loaded = true));
+init().then(() => {
+  loaded = true
+  const { grammar, input } = getSavedCode();
+  myCodeMirror.setValue(grammar);
+  inputTextDom.value = input;
+});
+
+inputTextDom.addEventListener("input", saveCode);
+myCodeMirror.on("change", saveCode);

--- a/static/style.css
+++ b/static/style.css
@@ -645,7 +645,14 @@ body {
   color: #7ef69d;
 }
 .cm-s-pest span.cm-constiable {
-  color: #51d3f6;
+  color: #4ea8d8;
+}
+.cm-s-pest span.cm-constiable-2 {
+  color: white;
+}
+
+.cm-s-pest span.cm-tag {
+  color: #f6dc51;
 }
 .cm-s-pest span.cm-error {
   background: #ac4142;


### PR DESCRIPTION
This PR adds support for labels in the web editor (solves #48).
I also added localstorage saving so whenever the page is reloaded or navigated to, the last saved state is loaded.
I also had to change the grammar definition for the editor to allow for the tags to be used, it should be correct, but it's better if someone checks on it.
I made a personal change by turning the rules inside the rule block in a white color, it should improve readability a bit, do let me know if any of the changes are unwanted. below is a picture of how it currently looks like:

![image](https://github.com/pest-parser/site/assets/59029985/31cbe892-4970-4e23-b46c-a19fcc82d29f)

