### PR TITLE
Move parser execution to a Web Worker with timeout handling

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,6 @@ features = [
   "HtmlCollection",
   "InputEvent",
   "Storage",
+  "CustomEvent",
 ]
 version = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,7 +72,7 @@ fn listen_for_input() {
             LAST_SELECTION = selected_option();
         }
 
-        parse_input();
+        trigger_worker();
     });
 
     select
@@ -85,7 +85,7 @@ fn wait_and_run() {
     let win = web_sys::window().expect_throw("no window");
     let func = Closure::<dyn FnOnce()>::once_into_js(|| {
         if unsafe { NEEDS_RUN } {
-            parse_input();
+            trigger_worker();
             unsafe {
                 NEEDS_RUN = false;
             }
@@ -96,22 +96,11 @@ fn wait_and_run() {
         .unwrap_throw();
 }
 
-fn parse_input() {
-    let input = element::<HtmlTextAreaElement>(".editor-input-text");
-    let output = element::<HtmlTextAreaElement>(".editor-output");
-
-    if let Some(rule) = selected_option() {
-        let vm = unsafe { VM.as_ref().expect_throw("no VM") };
-
-        match vm.parse(&rule, &input.value()) {
-            Ok(pairs) => {
-                let lines: Vec<_> = pairs.map(|pair| format_pair(pair, 0, true)).collect();
-                let lines = lines.join("\n");
-
-                output.set_value(lines.as_str());
-            }
-            Err(error) => output.set_value(&format!("{}", error.renamed_rules(|r| r.to_string()))),
-        };
+fn trigger_worker() {
+    if let Some(window) = web_sys::window() {
+        if let Ok(event) = web_sys::CustomEvent::new("trigger_worker") {
+            let _ = window.dispatch_event(&event);
+        }
     }
 }
 
@@ -217,7 +206,7 @@ fn compile_grammar(grammar: &str) -> Vec<HashMap<String, String>> {
 
     add_rules_to_select(ast.iter().map(|rule| rule.name.as_str()).collect());
 
-    parse_input();
+    trigger_worker();
 
     vec![]
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,3 +335,16 @@ pub fn format(grammar: JsValue) -> JsValue {
     serde_wasm_bindgen::to_value(&fmt.format().unwrap())
         .expect_throw("could not serialize grammar results")
 }
+
+#[wasm_bindgen]
+pub fn parse(rule: String, input: String) -> String {
+    let vm = unsafe { VM.as_ref().expect_throw("no VM") };
+
+    match vm.parse(&rule, &input) {
+        Ok(pairs) => {
+            let lines: Vec<_> = pairs.map(|pair| format_pair(pair, 0, true)).collect();
+            lines.join("\n")
+        }
+        Err(error) => format!("{}", error.renamed_rules(|r| r.to_string())),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -285,6 +285,11 @@ fn line_col(pos: usize, input: &str) -> String {
 }
 
 fn add_rules_to_select(mut rules: Vec<&str>) {
+    // safe guard to run in web worker
+    if web_sys::window().is_none() {
+        return;
+    }
+
     let select = element::<HtmlSelectElement>(".editor-input-select");
 
     while let Some(node) = select.first_child() {
@@ -319,6 +324,11 @@ pub fn lint(grammar: JsValue) -> JsValue {
 
 #[wasm_bindgen(start)]
 pub fn start() {
+    // safe guard to run in web worker
+    if web_sys::window().is_none() {
+        return;
+    }
+
     if let Ok(last_selected) = storage().get_item("last-selected-rule") {
         unsafe {
             LAST_SELECTION = last_selected;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use pest_vm::Vm;
 use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use web_sys::{Document, Event, InputEvent, Node};
-use web_sys::{HtmlOptionElement, HtmlSelectElement, HtmlTextAreaElement};
+use web_sys::{HtmlOptionElement, HtmlSelectElement};
 
 static mut NEEDS_RUN: bool = false;
 static mut VM: Option<Vm> = None;

--- a/static/scripts/editor.ts
+++ b/static/scripts/editor.ts
@@ -8,6 +8,37 @@ import { initShareButton } from "./shareButton";
 
 let loaded = false;
 
+let parserWorker: Worker | null = null;
+let parseTimeout: number | null = null;
+let parseId = 0;
+
+function spawnWorker() {
+  if (parserWorker) {
+    parserWorker.terminate();
+  }
+  parserWorker = new Worker(new URL("./parser_worker.ts", import.meta.url), {
+    type: "module",
+  });
+
+  parserWorker.onmessage = (e) => {
+    if (parseTimeout !== null) {
+      clearTimeout(parseTimeout);
+      parseTimeout = null;
+    }
+
+    const { id, type, result, error } = e.data;
+    if (id === parseId) {
+      if (type === "success") {
+        outputDom.value = result;
+      } else {
+        outputDom.value = error;
+      }
+    }
+  };
+}
+
+spawnWorker();
+
 const editorDom = document.querySelector<HTMLLinkElement>(".editor")!;
 const gridDom = document.querySelector<HTMLDivElement>(".editor-grid")!;
 const inputDom = document.querySelector<HTMLDivElement>(".editor-input")!;
@@ -195,3 +226,33 @@ init().then(() => {
 inputTextDom.addEventListener("input", saveCode);
 myCodeMirror.on("change", saveCode);
 editorInputSelect?.addEventListener("change", saveRule);
+
+window.addEventListener("trigger_worker", () => {
+  if (!loaded || !parserWorker) return;
+  const rule = editorInputSelect?.value;
+  if (!rule || rule === "...") return;
+
+  parseId++;
+  const currentId = parseId;
+
+  if (parseTimeout !== null) {
+    window.clearTimeout(parseTimeout);
+  }
+
+  parseTimeout = window.setTimeout(() => {
+    if (parseId === currentId) {
+      outputDom.value = "Parser timeout";
+      spawnWorker();
+    }
+  }, 1000);
+
+  const grammar = myCodeMirror.getValue();
+  const input = inputTextDom.value;
+
+  parserWorker.postMessage({
+    id: parseId,
+    grammar,
+    rule,
+    input,
+  });
+});

--- a/static/scripts/editor.ts
+++ b/static/scripts/editor.ts
@@ -21,18 +21,21 @@ function spawnWorker() {
   });
 
   parserWorker.onmessage = (e) => {
+
+    const { id, type, result, error } = e.data;
+    if (id !== parseId) {
+      return;
+    }
+
     if (parseTimeout !== null) {
       clearTimeout(parseTimeout);
       parseTimeout = null;
     }
 
-    const { id, type, result, error } = e.data;
-    if (id === parseId) {
-      if (type === "success") {
-        outputDom.value = result;
-      } else {
-        outputDom.value = error;
-      }
+    if (type === "success") {
+      outputDom.value = result;
+    } else {
+      outputDom.value = error;
     }
   };
 }

--- a/static/scripts/editor.ts
+++ b/static/scripts/editor.ts
@@ -21,7 +21,6 @@ function spawnWorker() {
   });
 
   parserWorker.onmessage = (e) => {
-
     const { id, type, result, error } = e.data;
     if (id !== parseId) {
       return;

--- a/static/scripts/parser_worker.ts
+++ b/static/scripts/parser_worker.ts
@@ -1,0 +1,27 @@
+import init, { lint, parse } from "../../pkg/pest_site.js";
+
+let loaded = false;
+let lastGrammar: string | null = null;
+
+init().then(() => {
+    loaded = true;
+});
+
+onmessage = (e) => {
+    if (!loaded) return;
+
+    const { id, grammar, rule, input } = e.data;
+
+    try {
+        // This has the side effect of compiling the grammar for the wasm worker.
+        if (grammar !== lastGrammar) {
+            lint(grammar);
+            lastGrammar = grammar;
+        }
+
+        const result = parse(rule, input);
+        postMessage({ id, type: "success", result });
+    } catch (err: any) {
+        postMessage({ id, type: "error", error: err.toString() });
+    }
+};

--- a/static/scripts/parser_worker.ts
+++ b/static/scripts/parser_worker.ts
@@ -4,24 +4,24 @@ let loaded = false;
 let lastGrammar: string | null = null;
 
 init().then(() => {
-    loaded = true;
+  loaded = true;
 });
 
 onmessage = (e) => {
-    if (!loaded) return;
+  if (!loaded) return;
 
-    const { id, grammar, rule, input } = e.data;
+  const { id, grammar, rule, input } = e.data;
 
-    try {
-        // This has the side effect of compiling the grammar for the wasm worker.
-        if (grammar !== lastGrammar) {
-            lint(grammar);
-            lastGrammar = grammar;
-        }
-
-        const result = parse(rule, input);
-        postMessage({ id, type: "success", result });
-    } catch (err: any) {
-        postMessage({ id, type: "error", error: err.toString() });
+  try {
+    // This has the side effect of compiling the grammar for the wasm worker.
+    if (grammar !== lastGrammar) {
+      lint(grammar);
+      lastGrammar = grammar;
     }
+
+    const result = parse(rule, input);
+    postMessage({ id, type: "success", result });
+  } catch (err) {
+    postMessage({ id, type: "error", error: err.toString() });
+  }
 };

--- a/static/scripts/parser_worker.ts
+++ b/static/scripts/parser_worker.ts
@@ -20,7 +20,8 @@ function processMessage(e: MessageEvent) {
   try {
     // This has the side effect of compiling the grammar for the wasm worker.
     if (grammar !== lastGrammar) {
-      lint(grammar);
+      const errors = lint(grammar);
+      if (errors.length > 0) return;
       lastGrammar = grammar;
     }
 

--- a/static/scripts/parser_worker.ts
+++ b/static/scripts/parser_worker.ts
@@ -27,15 +27,18 @@ function processMessage(e: MessageEvent) {
     const result = parse(rule, input);
     postMessage({ id, type: "success", result });
   } catch (err) {
-    postMessage({ id, type: "error", error: err.toString() });
+    postMessage({
+      id,
+      type: "error",
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 
-onmessage = (e) => {
+self.addEventListener("message", (e) => {
   if (!loaded) {
     pendingMessage = e;
     return;
   }
   processMessage(e);
-};
-
+});

--- a/static/scripts/parser_worker.ts
+++ b/static/scripts/parser_worker.ts
@@ -3,13 +3,18 @@ import init, { lint, parse } from "../../pkg/pest_site.js";
 let loaded = false;
 let lastGrammar: string | null = null;
 
+let pendingMessage: MessageEvent | null = null;
+
 init().then(() => {
   loaded = true;
+  if (pendingMessage) {
+    const e = pendingMessage;
+    pendingMessage = null;
+    processMessage(e);
+  }
 });
 
-onmessage = (e) => {
-  if (!loaded) return;
-
+function processMessage(e: MessageEvent) {
   const { id, grammar, rule, input } = e.data;
 
   try {
@@ -24,4 +29,13 @@ onmessage = (e) => {
   } catch (err) {
     postMessage({ id, type: "error", error: err.toString() });
   }
+}
+
+onmessage = (e) => {
+  if (!loaded) {
+    pendingMessage = e;
+    return;
+  }
+  processMessage(e);
 };
+


### PR DESCRIPTION
This PR resolves the issue #66, recursive grammar would halt the entire site. The solution, as suggested in the issue, was to move the parsing logic to a web worker and attaching a timeout to it.

Changes:

- `src/lib.rs`:
  - Substituted direct `parse_input()` calls with a custom `trigger_worker` event dispatch.
  - Exposed a new `pub fn parse(rule: String, input: String) -> String` to be explicitly called by the worker, completely avoiding unnecessary DOM manipulation.

- `static/scripts/parser_worker.ts`:
  - Implemented a lean Web Worker that loads the Wasm module, caches grammar compilations via `lint`, and responds to main thread  `parse` requests.

- `static/scripts/editor.ts`:
  - Wired up `parserWorker` spawning and termination. Added a `parseId` mechanism to ensure responses map correctly to the active input session.
  - Implemented the `window.setTimeout(..., 1000)` wrapper to manage worker termination and timeout UI updates.

- `Cargo.toml`:
  - Added the `CustomEvent` feature to `web-sys` dependencies to support the new event-driven refactor.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Parsing now runs in a background web worker to keep the UI responsive.
  * Added a 1000ms parser timeout with automatic worker restart on hung parses.
  * Implemented grammar caching to avoid unnecessary recompilation and speed repeated checks.
  * Parsing can be triggered via dispatched browser events for decoupled integrations.
  * Improved worker lifecycle and result handling for more reliable parsing.
  * Exposed a direct parse entrypoint for integration use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->